### PR TITLE
Skip DLL presence check in injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ Make sure the DLL file is built and available in either of these paths:
 Launch the target application (e.g., LockDownBrowser.exe).  
 
 Run the injector:  
-`python inject.py`  
+```
+python inject.py  
+```
 
 The script:  
 

--- a/inject.py
+++ b/inject.py
@@ -9,7 +9,7 @@ dll_file = os.path.join(os.getcwd(), "DLLHooks.dll")
 if not os.path.exists(dll_file):
     dll_file = os.path.join(os.getcwd(), "DLLHooks/Release/DLLHooks.dll")
     if not os.path.exists(dll_file):
-        raise FileNotFoundError("DLLHooks.dll not found in expected directories.")
+        print("Warning: DLLHooks.dll not found in expected directories. Continuing without a DLL (injection will be skipped).")
 
 monitored_process = "LockDownBrowser"
 
@@ -34,7 +34,10 @@ while True:
             print(f"Target detected: {task_name} (PID: {pid})")
             try:
                 agent.attach_to_pid(pid)
-                agent.inject_shared_library(dll_file)
+                if os.path.exists(dll_file):
+                    agent.inject_shared_library(dll_file)
+                else:
+                    print("DLL file not present; skipping injection step.")
                 agent.cleanup()
                 found = True
                 break


### PR DESCRIPTION
## Problem
The injector script previously required a built DLL file to exist before running, raising `FileNotFoundError` if not found. This blocked development workflows where testing the monitoring/injection logic was needed before a complete DLL build was available.

## Solution
Modified `inject.py` to gracefully handle missing DLL files:
- Changed from raising `FileNotFoundError` to printing a warning and continuing execution
- Added conditional check before attempting DLL injection; skips injection if file is not present
- Allows the injector to run and monitor for the target LockDown Browser process regardless of DLL build status

Also updated `README.md` code snippet formatting from inline backticks to a fenced code block for better readability.

## Testing
The injector now starts successfully and waits for the target process even when no DLL is available, enabling safer development and integration testing workflows.